### PR TITLE
Add kofta_metadata:get_broker/1 and fix producer batcher bug

### DIFF
--- a/src/kofta_cluster.erl
+++ b/src/kofta_cluster.erl
@@ -3,6 +3,7 @@
 -export([
     activate_broker/2,
     deactivate_broker/2,
+    active_brokers/0,
     active_broker/0
 ]).
 
@@ -30,7 +31,7 @@ deactivate_broker(Host, Port) ->
     Broker :: {binary(), integer()}. % host, port
 
 active_broker() ->
-    Tab = ets:tab2list(active_brokers),
+    Tab = active_brokers(),
     Size = length(Tab),
     case Size of
         0 ->
@@ -40,3 +41,10 @@ active_broker() ->
             {Broker} = lists:nth(RandomIndex, Tab),
             {ok, Broker}
     end.
+
+
+-spec active_brokers() -> [Broker] when
+    Broker :: {binary(), integer()}. % host, port
+
+active_brokers() ->
+    ets:tab2list(active_brokers).

--- a/src/kofta_producer_batcher.erl
+++ b/src/kofta_producer_batcher.erl
@@ -74,15 +74,15 @@ handle_call({msg, Topic, Partition, KVs}, From, State0) ->
         clients=dict:append({Topic, Partition}, From, Clients),
         msgs=dict:append_list({Topic, Partition}, KVs, Msgs)
     },
-    format_return(noreply, State1).
+    format_return(State1).
 
 
 handle_cast(_Msg, State) ->
-    format_return(noreply, State).
+    format_return(State).
 
 
 handle_info(timeout, State) ->
-    format_return(noreply, State).
+    format_return(State).
 
 
 terminate(_Reason, _State) ->
@@ -90,15 +90,14 @@ terminate(_Reason, _State) ->
 
 
 code_change(_OldVsn, State, _Extra) ->
-    format_return(ok, State).
+    {ok, State}.
 
 
--spec format_return(Type, State) -> {Type, State} | {Type, State, Timeout} when
-    Type :: atom(),
+-spec format_return(State) -> {noreply, State} | {noreply, State, Timeout} when
     State :: #st{},
     Timeout :: integer().
 
-format_return(Type, State) ->
+format_return(State) ->
     #st{
         clients=Clients,
         last_batch=LastBatch,
@@ -109,11 +108,11 @@ format_return(Type, State) ->
     % is_empty isn't in r16
     case HasWaiters and TimedOut of
         false ->
-            {Type, State};
+            {noreply, State};
         true ->
             case make_request(State) of
                 {ok, NewState} ->
-                    {Type, NewState, get_timeout(NewState)};
+                    {noreply, NewState, get_timeout(NewState)};
                 {error, Reason, NewState} ->
                     {stop, Reason, NewState}
             end
@@ -229,7 +228,7 @@ get_timeout(State) ->
         Diff when Diff < 0 ->
             0;
         Diff ->
-            Diff/1000
+            round(Diff/1000)
     end.
 
 


### PR DESCRIPTION
This PR contains two changes:

1) Add kofta_metadata:get_broker/1. It's just a function to return the host and port for a broker given a broker ID. There's some new logic in the metadata FSM to support these requests.
2) A fix to a bug in kofta_producer_batcher which caused the producer to only aggregate requests and not execute those requests.
